### PR TITLE
Add readme badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,28 +2,28 @@
 <!-- Badges section -->
 <div align="center">
 
-![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)
-![GitHub stars](https://img.shields.io/github/stars/matrixbytes/Obfussor)
-![GitHub forks](https://img.shields.io/github/forks/matrixbytes/Obfussor)
-![GitHub issues](https://img.shields.io/github/issues/matrixbytes/Obfussor)
-![GitHub pull requests](https://img.shields.io/github/issues-pr/matrixbytes/Obfussor)
-![Last commit](https://img.shields.io/github/last-commit/matrixbytes/Obfussor)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./LICENSE)  
+[![GitHub stars](https://img.shields.io/github/stars/matrixbytes/Obfussor)](https://github.com/matrixbytes/Obfussor/stargazers)  
+[![GitHub forks](https://img.shields.io/github/forks/matrixbytes/Obfussor)](https://github.com/matrixbytes/Obfussor/network/members)  
+[![GitHub issues](https://img.shields.io/github/issues/matrixbytes/Obfussor)](https://github.com/matrixbytes/Obfussor/issues)  
+[![GitHub pull requests](https://img.shields.io/github/issues-pr/matrixbytes/Obfussor)](https://github.com/matrixbytes/Obfussor/pulls)  
+[![Last commit](https://img.shields.io/github/last-commit/matrixbytes/Obfussor)](https://github.com/matrixbytes/Obfussor/commits/main)  
 
-![Rust](https://img.shields.io/badge/rust-%23000000.svg?style=flat&logo=rust&logoColor=white)
-![TypeScript](https://img.shields.io/badge/typescript-%23007ACC.svg?style=flat&logo=typescript&logoColor=white)
-![Angular](https://img.shields.io/badge/angular-%23DD0031.svg?style=flat&logo=angular&logoColor=white)
-![Tauri](https://img.shields.io/badge/tauri-%2324C8DB.svg?style=flat&logo=tauri&logoColor=%23FFFFFF)
-![LLVM](https://img.shields.io/badge/LLVM-262D3A?style=flat&logo=llvm&logoColor=white)
-![CSS3](https://img.shields.io/badge/css3-%231572B6.svg?style=flat&logo=css3&logoColor=white)
-![HTML5](https://img.shields.io/badge/html5-%23E34F26.svg?style=flat&logo=html5&logoColor=white)
-![Nix](https://img.shields.io/badge/NIX-5277C3.svg?style=flat&logo=NixOS&logoColor=white)
+[![Rust](https://img.shields.io/badge/rust-%23000000.svg?style=flat&logo=rust&logoColor=white)](https://www.rust-lang.org/)  
+[![TypeScript](https://img.shields.io/badge/typescript-%23007ACC.svg?style=flat&logo=typescript&logoColor=white)](https://www.typescriptlang.org/)  
+[![Angular](https://img.shields.io/badge/angular-%23DD0031.svg?style=flat&logo=angular&logoColor=white)](https://angular.io/)  
+[![Tauri](https://img.shields.io/badge/tauri-%2324C8DB.svg?style=flat&logo=tauri&logoColor=%23FFFFFF)](https://tauri.app/)  
+[![LLVM](https://img.shields.io/badge/LLVM-262D3A?style=flat&logo=llvm&logoColor=white)](https://llvm.org/)  
+[![CSS3](https://img.shields.io/badge/css3-%231572B6.svg?style=flat&logo=css3&logoColor=white)](https://www.w3.org/Style/CSS/)  
+[![HTML5](https://img.shields.io/badge/html5-%23E34F26.svg?style=flat&logo=html5&logoColor=white)](https://developer.mozilla.org/docs/Web/HTML)  
+[![Nix](https://img.shields.io/badge/NIX-5277C3.svg?style=flat&logo=NixOS&logoColor=white)](https://nixos.org/)
 
-![Hacktoberfest](https://img.shields.io/badge/Hacktoberfest-friendly-blueviolet)
+[![Hacktoberfest](https://img.shields.io/badge/Hacktoberfest-friendly-blueviolet)](https://hacktoberfest.com/)
 
-![Contributors](https://img.shields.io/github/contributors/matrixbytes/Obfussor)
-![Code Size](https://img.shields.io/github/languages/code-size/matrixbytes/Obfussor)
-![Top Language](https://img.shields.io/github/languages/top/matrixbytes/Obfussor)
-![Website](https://img.shields.io/website?url=https%3A%2F%2Fmatrixbytes.github.io%2FObfussor%2F)
+[![Contributors](https://img.shields.io/github/contributors/matrixbytes/Obfussor)](https://github.com/matrixbytes/Obfussor/graphs/contributors)  
+[![Code Size](https://img.shields.io/github/languages/code-size/matrixbytes/Obfussor)](https://github.com/matrixbytes/Obfussor)  
+[![Top Language](https://img.shields.io/github/languages/top/matrixbytes/Obfussor)](https://github.com/matrixbytes/Obfussor)  
+[![Website](https://img.shields.io/website?url=https%3A%2F%2Fmatrixbytes.github.io%2FObfussor%2F)](https://matrixbytes.github.io/Obfussor/)
 
 ![Obfucc](./assets/llvm-obfucc.png)
 </div>

--- a/README.md
+++ b/README.md
@@ -2,31 +2,17 @@
 <!-- Badges section -->
 <div align="center">
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./LICENSE)  
-[![GitHub stars](https://img.shields.io/github/stars/matrixbytes/Obfussor)](https://github.com/matrixbytes/Obfussor/stargazers)  
-[![GitHub forks](https://img.shields.io/github/forks/matrixbytes/Obfussor)](https://github.com/matrixbytes/Obfussor/network/members)  
-[![GitHub issues](https://img.shields.io/github/issues/matrixbytes/Obfussor)](https://github.com/matrixbytes/Obfussor/issues)  
-[![GitHub pull requests](https://img.shields.io/github/issues-pr/matrixbytes/Obfussor)](https://github.com/matrixbytes/Obfussor/pulls)  
-[![Last commit](https://img.shields.io/github/last-commit/matrixbytes/Obfussor)](https://github.com/matrixbytes/Obfussor/commits/main)  
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./LICENSE) [![GitHub stars](https://img.shields.io/github/stars/matrixbytes/Obfussor)](https://github.com/matrixbytes/Obfussor/stargazers) [![GitHub forks](https://img.shields.io/github/forks/matrixbytes/Obfussor)](https://github.com/matrixbytes/Obfussor/network/members) [![GitHub issues](https://img.shields.io/github/issues/matrixbytes/Obfussor)](https://github.com/matrixbytes/Obfussor/issues) [![GitHub pull requests](https://img.shields.io/github/issues-pr/matrixbytes/Obfussor)](https://github.com/matrixbytes/Obfussor/pulls) [![Last commit](https://img.shields.io/github/last-commit/matrixbytes/Obfussor)](https://github.com/matrixbytes/Obfussor/commits/main)
 
-[![Rust](https://img.shields.io/badge/rust-%23000000.svg?style=flat&logo=rust&logoColor=white)](https://www.rust-lang.org/)  
-[![TypeScript](https://img.shields.io/badge/typescript-%23007ACC.svg?style=flat&logo=typescript&logoColor=white)](https://www.typescriptlang.org/)  
-[![Angular](https://img.shields.io/badge/angular-%23DD0031.svg?style=flat&logo=angular&logoColor=white)](https://angular.io/)  
-[![Tauri](https://img.shields.io/badge/tauri-%2324C8DB.svg?style=flat&logo=tauri&logoColor=%23FFFFFF)](https://tauri.app/)  
-[![LLVM](https://img.shields.io/badge/LLVM-262D3A?style=flat&logo=llvm&logoColor=white)](https://llvm.org/)  
-[![CSS3](https://img.shields.io/badge/css3-%231572B6.svg?style=flat&logo=css3&logoColor=white)](https://www.w3.org/Style/CSS/)  
-[![HTML5](https://img.shields.io/badge/html5-%23E34F26.svg?style=flat&logo=html5&logoColor=white)](https://developer.mozilla.org/docs/Web/HTML)  
-[![Nix](https://img.shields.io/badge/NIX-5277C3.svg?style=flat&logo=NixOS&logoColor=white)](https://nixos.org/)
+[![Rust](https://img.shields.io/badge/rust-%23000000.svg?style=flat&logo=rust&logoColor=white)](https://www.rust-lang.org/) [![TypeScript](https://img.shields.io/badge/typescript-%23007ACC.svg?style=flat&logo=typescript&logoColor=white)](https://www.typescriptlang.org/) [![Angular](https://img.shields.io/badge/angular-%23DD0031.svg?style=flat&logo=angular&logoColor=white)](https://angular.io/) [![Tauri](https://img.shields.io/badge/tauri-%2324C8DB.svg?style=flat&logo=tauri&logoColor=%23FFFFFF)](https://tauri.app/) [![LLVM](https://img.shields.io/badge/LLVM-262D3A?style=flat&logo=llvm&logoColor=white)](https://llvm.org/) [![CSS3](https://img.shields.io/badge/css3-%231572B6.svg?style=flat&logo=css3&logoColor=white)](https://www.w3.org/Style/CSS/) [![HTML5](https://img.shields.io/badge/html5-%23E34F26.svg?style=flat&logo=html5&logoColor=white)](https://developer.mozilla.org/docs/Web/HTML) [![Nix](https://img.shields.io/badge/NIX-5277C3.svg?style=flat&logo=NixOS&logoColor=white)](https://nixos.org/)
 
 [![Hacktoberfest](https://img.shields.io/badge/Hacktoberfest-friendly-blueviolet)](https://hacktoberfest.com/)
 
-[![Contributors](https://img.shields.io/github/contributors/matrixbytes/Obfussor)](https://github.com/matrixbytes/Obfussor/graphs/contributors)  
-[![Code Size](https://img.shields.io/github/languages/code-size/matrixbytes/Obfussor)](https://github.com/matrixbytes/Obfussor)  
-[![Top Language](https://img.shields.io/github/languages/top/matrixbytes/Obfussor)](https://github.com/matrixbytes/Obfussor)  
-[![Website](https://img.shields.io/website?url=https%3A%2F%2Fmatrixbytes.github.io%2FObfussor%2F)](https://matrixbytes.github.io/Obfussor/)
+[![Contributors](https://img.shields.io/github/contributors/matrixbytes/Obfussor)](https://github.com/matrixbytes/Obfussor/graphs/contributors) [![Code Size](https://img.shields.io/github/languages/code-size/matrixbytes/Obfussor)](https://github.com/matrixbytes/Obfussor) [![Top Language](https://img.shields.io/github/languages/top/matrixbytes/Obfussor)](https://github.com/matrixbytes/Obfussor) [![Website](https://img.shields.io/website?url=https%3A%2F%2Fmatrixbytes.github.io%2FObfussor%2F)](https://matrixbytes.github.io/Obfussor/)
 
 ![Obfucc](./assets/llvm-obfucc.png)
 </div>
+
 
 Obfussor - LLVM is a high-performance binary obfuscation framework that leverages LLVM's compiler infrastructure to transform source code into hardened, reverse-engineering-resistant binaries. Built for scenarios where intellectual property protection is non-negotiable.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,31 @@
 # LLVM - Obfussor
+<!-- Badges section -->
+<div align="center">
 
+![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)
+![GitHub stars](https://img.shields.io/github/stars/matrixbytes/Obfussor)
+![GitHub forks](https://img.shields.io/github/forks/matrixbytes/Obfussor)
+![GitHub issues](https://img.shields.io/github/issues/matrixbytes/Obfussor)
+![GitHub pull requests](https://img.shields.io/github/issues-pr/matrixbytes/Obfussor)
+![Last commit](https://img.shields.io/github/last-commit/matrixbytes/Obfussor)
+
+![Rust](https://img.shields.io/badge/rust-%23000000.svg?style=flat&logo=rust&logoColor=white)
+![TypeScript](https://img.shields.io/badge/typescript-%23007ACC.svg?style=flat&logo=typescript&logoColor=white)
+![Angular](https://img.shields.io/badge/angular-%23DD0031.svg?style=flat&logo=angular&logoColor=white)
+![Tauri](https://img.shields.io/badge/tauri-%2324C8DB.svg?style=flat&logo=tauri&logoColor=%23FFFFFF)
+![LLVM](https://img.shields.io/badge/LLVM-262D3A?style=flat&logo=llvm&logoColor=white)
+![CSS3](https://img.shields.io/badge/css3-%231572B6.svg?style=flat&logo=css3&logoColor=white)
+![HTML5](https://img.shields.io/badge/html5-%23E34F26.svg?style=flat&logo=html5&logoColor=white)
+![Nix](https://img.shields.io/badge/NIX-5277C3.svg?style=flat&logo=NixOS&logoColor=white)
+
+![Hacktoberfest](https://img.shields.io/badge/Hacktoberfest-friendly-blueviolet)
+
+![Contributors](https://img.shields.io/github/contributors/matrixbytes/Obfussor)
+![Code Size](https://img.shields.io/github/languages/code-size/matrixbytes/Obfussor)
+![Top Language](https://img.shields.io/github/languages/top/matrixbytes/Obfussor)
+![Website](https://img.shields.io/website?url=https%3A%2F%2Fmatrixbytes.github.io%2FObfussor%2F)
+
+</div>
 ![Obfucc](./assets/llvm-obfucc.png)
 
 Obfussor - LLVM is a high-performance binary obfuscation framework that leverages LLVM's compiler infrastructure to transform source code into hardened, reverse-engineering-resistant binaries. Built for scenarios where intellectual property protection is non-negotiable.

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@
 ![Top Language](https://img.shields.io/github/languages/top/matrixbytes/Obfussor)
 ![Website](https://img.shields.io/website?url=https%3A%2F%2Fmatrixbytes.github.io%2FObfussor%2F)
 
-</div>
 ![Obfucc](./assets/llvm-obfucc.png)
+</div>
 
 Obfussor - LLVM is a high-performance binary obfuscation framework that leverages LLVM's compiler infrastructure to transform source code into hardened, reverse-engineering-resistant binaries. Built for scenarios where intellectual property protection is non-negotiable.
 


### PR DESCRIPTION
📋 Description
Enhanced the README.md by adding a comprehensive collection of informative badges to provide quick project information and make the Obfussor repository more professional and inviting to contributors.

🎯 Changes Made
- Added essential project badges (license, stars, forks, issues, PRs, last commit)
- Added technology stack badges for Rust, TypeScript, Angular, Tauri, LLVM, CSS, HTML, Nix  
- Added prominent Hacktoberfest participation badge
- Added optional metrics badges (contributors, code size, top language, website)
- Organized badges in centered alignment for professional appearance
- Total of 19 badges exceeding minimum requirements

📝 Acceptance Criteria Met
- Badges added to README.md after title
- Minimum 10-12 badges included (19 total)
- All essential badges present
- Technology stack badges reflect actual tech used
- Hacktoberfest badge prominently displayed
- Badges properly formatted and clickable
- Badges centered and nicely aligned
- All badge links work correctly


